### PR TITLE
Add plugin header and implement functionality to hide admin bar for logged-in users

### DIFF
--- a/nobar-frontend.php
+++ b/nobar-frontend.php
@@ -6,3 +6,7 @@
  * Author: Olive Uzoma
  * Author URI: https://oliveuzoma.com
  */
+
+// Hide admin bar from the frontend for logged-in users
+add_filter( 'show_admin_bar', '__return_false' );
+ 

--- a/nobar-frontend.php
+++ b/nobar-frontend.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Plugin Name: NoBar Frontend
+ * Description: A lightweight plugin that hides the admin bar from the frontend for logged-in users.
+ * Version: 1.0.0
+ * Author: Olive Uzoma
+ * Author URI: https://oliveuzoma.com
+ */


### PR DESCRIPTION

**Description:**  
This pull request introduces two key updates to the NoBar Frontend plugin:

### Plugin Header: 
Added the initial plugin header containing essential metadata such as the plugin name, description, version, author information, and license details. This is necessary for proper identification and usage within WordPress.

   ```php
   /**
    * Plugin Name: NoBar Frontend
    * Description: A lightweight plugin that hides the admin bar from the frontend for logged-in users.
    * Version: 1.0.0
    * Author: Olive Uzoma
    * Author URI: https://oliveuzoma.com
    */
```

### Admin Bar Functionality

Implement a filter to hide the WordPress admin bar on the frontend for all logged-in users, enhancing the user experience by providing a cleaner, distraction-free browsing environment.

```php
// Hide admin bar from the frontend for logged-in users
add_filter( 'show_admin_bar', '__return_false' );

